### PR TITLE
fillScreen: trigger a redraw of the screen

### DIFF
--- a/src/Arduino_GigaDisplay_GFX.cpp
+++ b/src/Arduino_GigaDisplay_GFX.cpp
@@ -102,6 +102,7 @@ uint16_t GigaDisplay_GFX::getRawPixel(int16_t x, int16_t y) {
 
 void GigaDisplay_GFX::fillScreen(uint16_t color) {
   if (hasBuffer()) {
+    startWrite();
     uint8_t hi = color >> 8, lo = color & 0xFF;
     if (hi == lo) {
       memset(buffer, lo, WIDTH * HEIGHT * 2);
@@ -110,6 +111,7 @@ void GigaDisplay_GFX::fillScreen(uint16_t color) {
       for (i = 0; i < pixels; i++)
         buffer[i] = color;
     }
+    endWrite();
   }
 }
 


### PR DESCRIPTION
From the Forum thread:
https://forum.arduino.cc/t/problem-with-fillscreen/1218319

The following sketch does not show anything on the screen:
```
#include "Arduino.h"
//#include "SPI.h"
#include "Arduino_GigaDisplay_GFX.h"

GigaDisplay_GFX tft;

#define GC9A01A_CYAN    0x07FF
#define GC9A01A_RED     0xf800
#define GC9A01A_BLUE    0x001F
#define GC9A01A_GREEN   0x07E0
#define GC9A01A_MAGENTA 0xF81F
#define GC9A01A_WHITE   0xffff
#define GC9A01A_BLACK   0x0000
#define GC9A01A_YELLOW  0xFFE0
#define WHITE 0xffff
#define BLACK 0x0000

void setup() {

  Serial.begin(115200);

  tft.begin();

  tft.fillScreen(GC9A01A_GREEN);
  yield();
  delay(3000);
  tft.fillScreen(GC9A01A_BLUE);
  yield();
  delay(3000);
  tft.fillScreen(GC9A01A_YELLOW);
  Serial.println("Done");

}

void loop() {
  // put your main code here, to run repeatedly:

}
```
Problem was you implemented your own version of fillScreen, which did not have the startWrite() and more specific endWrite() calls in it, and as such your dirty flag was not set.