### PR TITLE
Update Arduino_GigaDisplay_GFX.h

### DIFF
--- a/src/Arduino_GigaDisplay_GFX.h
+++ b/src/Arduino_GigaDisplay_GFX.h
@@ -7,6 +7,7 @@
 #include "Adafruit_SPITFT.h"
 #include "dsi.h"
 #include "SDRAM.h"
+#include "rtos.h"
 
 class GigaDisplay_GFX : public Adafruit_GFX {
   public:


### PR DESCRIPTION
Added rtos.h to the include files section to as the type rtos cannot be found and the examples fail to compile without this change.