### PR TITLE
Allow caller to control when screen is updated

### DIFF
--- a/src/Arduino_GigaDisplay_GFX.cpp
+++ b/src/Arduino_GigaDisplay_GFX.cpp
@@ -40,7 +40,21 @@ void GigaDisplay_GFX::startWrite() {
 
 void GigaDisplay_GFX::endWrite() {
   //refresh_sem.release();
-  _refresh_thd->flags_set(0x1);
+  if (!buffering)
+    _refresh_thd->flags_set(0x1);
+}
+
+// If buffering, defer endWrite calls until endBuffering is called.
+void GigaDisplay_GFX::startBuffering() {
+  buffering = true;
+}
+
+void GigaDisplay_GFX::endBuffering() {
+  if (buffering)
+  {
+    buffering = false;
+    endWrite();
+  }
 }
 
 void GigaDisplay_GFX::drawPixel(int16_t x, int16_t y, uint16_t color) {

--- a/src/Arduino_GigaDisplay_GFX.cpp
+++ b/src/Arduino_GigaDisplay_GFX.cpp
@@ -102,6 +102,7 @@ uint16_t GigaDisplay_GFX::getRawPixel(int16_t x, int16_t y) {
 
 void GigaDisplay_GFX::fillScreen(uint16_t color) {
   if (hasBuffer()) {
+	startWrite();	// PR #3
     uint8_t hi = color >> 8, lo = color & 0xFF;
     if (hi == lo) {
       memset(buffer, lo, WIDTH * HEIGHT * 2);
@@ -110,6 +111,7 @@ void GigaDisplay_GFX::fillScreen(uint16_t color) {
       for (i = 0; i < pixels; i++)
         buffer[i] = color;
     }
+    endWrite();		// PR #3
   }
 }
 
@@ -215,19 +217,23 @@ void GigaDisplay_GFX::drawFastHLine(int16_t x, int16_t y, int16_t w,
 
 void GigaDisplay_GFX::drawFastRawVLine(int16_t x, int16_t y, int16_t h,
                                        uint16_t color) {
+  startWrite();
   // x & y already in raw (rotation 0) coordinates, no need to transform.
   uint16_t *buffer_ptr = buffer + y * WIDTH + x;
   for (int16_t i = 0; i < h; i++) {
     (*buffer_ptr) = color;
     buffer_ptr += WIDTH;
   }
+  endWrite();
 }
 
 void GigaDisplay_GFX::drawFastRawHLine(int16_t x, int16_t y, int16_t w,
                                        uint16_t color) {
+  startWrite();
   // x & y already in raw (rotation 0) coordinates, no need to transform.
   uint32_t buffer_index = y * WIDTH + x;
   for (uint32_t i = buffer_index; i < buffer_index + w; i++) {
     buffer[i] = color;
   }
+  endWrite();
 }

--- a/src/Arduino_GigaDisplay_GFX.h
+++ b/src/Arduino_GigaDisplay_GFX.h
@@ -31,6 +31,8 @@ class GigaDisplay_GFX : public Adafruit_GFX {
 
     void startWrite();
     void endWrite();
+    void startBuffering();
+    void endBuffering();
 
     uint16_t color565(uint8_t red, uint8_t green, uint8_t blue) {
       return ((red & 0xF8) << 8) | ((green & 0xFC) << 3) | (blue >> 3);
@@ -45,7 +47,8 @@ class GigaDisplay_GFX : public Adafruit_GFX {
   private:
     Arduino_H7_Video* display;
     void refresh_if_needed();
-    bool need_refresh = false;
+    //bool need_refresh = false;
+    bool buffering = false;
     uint32_t last_refresh = 0;
     rtos::Thread* _refresh_thd;
 };


### PR DESCRIPTION
Added two new calls startBuffering() and endBuffering(). By bracketing a sequence of GFX calls between these, the endWrite() is deferred to the end of the sequence and the display is only updated from the buffer once, rather than after every call.
This allows caller to remove flickering and draw smoothly, especially in the common case when the first call is to clear the screen.

Code that does not use these new routines works as before (there is an endWrite at the end of each GFX call)

Missing endWrites mentioned in PR #3 are incorporated here as well.