### PR TITLE
Update for zephyr

### DIFF
--- a/src/Arduino_GigaDisplay_GFX.cpp
+++ b/src/Arduino_GigaDisplay_GFX.cpp
@@ -1,6 +1,13 @@
 
 #include "Arduino_GigaDisplay_GFX.h"
+
+#ifdef __MBED__
 #include "platform/mbed_critical.h"
+#endif
+
+#ifdef __ZEPHYR
+#include "Arduino_GigaDisplay.h"
+#endif
 
 GigaDisplay_GFX::GigaDisplay_GFX() : Adafruit_GFX(480, 800) {
 
@@ -13,6 +20,7 @@ GigaDisplay_GFX::~GigaDisplay_GFX(void) {
 
 //rtos::Semaphore refresh_sem(1);
 
+#ifdef __MBED__
 void GigaDisplay_GFX::refresh_if_needed() {
   while (1) {
     rtos::ThisThread::flags_wait_any(0x1);
@@ -23,15 +31,40 @@ void GigaDisplay_GFX::refresh_if_needed() {
     delay(10);
   }
 }
-
+#endif
 
 void GigaDisplay_GFX::begin() {
+#ifdef __MBED__
     display = new Arduino_H7_Video(480, 800, GigaDisplayShield);
     display->begin();
     buffer = (uint16_t*)ea_malloc(this->width() * this-> height() * 2);
     _refresh_thd = new rtos::Thread(osPriorityHigh);
     _refresh_thd->start(mbed::callback(this, &GigaDisplay_GFX::refresh_if_needed));
     //buffer = (uint16_t*)dsi_getActiveFrameBuffer();
+#elif defined(__ZEPHYR__)
+    display = new Display();
+    display->begin();
+#ifdef CONFIG_SHARED_MULTI_HEAP
+    void* ptrFB = this->display->getFrameBuffer();
+    if (ptrFB == nullptr){
+      Serial.println("Memory not allocated successfully." );
+      while(1){}
+    }
+    // Cast the void pointer to an int pointer to use it
+    buffer = static_cast<uint16_t*>(ptrFB);
+    //buffer = (uint16_t*)shared_multi_heap_aligned_alloc(SMH_REG_ATTR_EXTERNAL, 16, (this->width() * this-> height() * sizeof(uint16_t)));
+#else
+    SDRAM.begin();
+    buffer = (uint16_t*)SDRAM.malloc(this->width() * this-> height() * sizeof(uint16_t));
+#endif    
+    sizeof_framebuffer = this->width() * this-> height() * sizeof(uint16_t);
+    this->display->setFrameDesc(this->width(), this-> height(), this-> width(), sizeof_framebuffer);
+    Serial.print("Buffer: 0x"); Serial.println((uint32_t)buffer, HEX);
+    
+    // turn on the display backlight
+    pinMode(74, OUTPUT);
+    digitalWrite(74, HIGH);
+#endif
 }
 
 void GigaDisplay_GFX::startWrite() {
@@ -40,8 +73,14 @@ void GigaDisplay_GFX::startWrite() {
 
 void GigaDisplay_GFX::endWrite() {
   //refresh_sem.release();
+#ifdef __MBED__
   if (!buffering)
     _refresh_thd->flags_set(0x1);
+#elif defined(__ZEPHYR__)
+  if (!buffering)
+     this->display->write8(0, 0, buffer);
+#endif
+
 }
 
 // If buffering, defer endWrite calls until endBuffering is called.

--- a/src/Arduino_GigaDisplay_GFX.cpp
+++ b/src/Arduino_GigaDisplay_GFX.cpp
@@ -59,7 +59,7 @@ void GigaDisplay_GFX::begin() {
 #endif    
     sizeof_framebuffer = this->width() * this-> height() * sizeof(uint16_t);
     this->display->setFrameDesc(this->width(), this-> height(), this-> width(), sizeof_framebuffer);
-    Serial.print("Buffer: 0x"); Serial.println((uint32_t)buffer, HEX);
+    //Serial.print("Buffer: 0x"); Serial.println((uint32_t)buffer, HEX);
     
     // turn on the display backlight
     pinMode(74, OUTPUT);
@@ -290,3 +290,38 @@ void GigaDisplay_GFX::drawFastRawHLine(int16_t x, int16_t y, int16_t w,
   }
   endWrite();
 }
+
+
+#if defined(__ZEPHYR__)
+void GigaDisplay_GFX::drawGrayscaleBitmapScaled(int16_t width_image, int16_t height_image, uint8_t scale, uint8_t *pixels) {
+  
+  int yDisplay = (height() - (height_image * scale)) / 2;
+  
+  for (int yCamera = 0; yCamera < height_image; yCamera++) {
+    int xDisplay = (width() - (width_image * scale)) / 2;
+    for (int xCamera = 0; xCamera < width_image; xCamera++) {
+      uint16_t rgbPixel = color565(*pixels, *pixels, *pixels);
+      fillRect(xDisplay, yDisplay, scale, scale, rgbPixel);
+      pixels++;
+      xDisplay += scale;
+    }
+    yDisplay += scale;
+  }
+}
+
+void GigaDisplay_GFX::drawRGBBitmapScaled(int16_t width_image, int16_t height_image, uint8_t scale, uint16_t *pixels) {
+  
+  int yDisplay = (height() - (height_image * scale)) / 2;
+  
+  for (int yCamera = 0; yCamera < height_image; yCamera++) {
+    int xDisplay = (width() - (width_image * scale)) / 2;
+    for (int xCamera = 0; xCamera < width_image; xCamera++) {
+      fillRect(xDisplay, yDisplay, scale, scale, *pixels++);
+      xDisplay += scale;
+    }
+    yDisplay += scale;
+  }
+  
+}
+  
+#endif

--- a/src/Arduino_GigaDisplay_GFX.h
+++ b/src/Arduino_GigaDisplay_GFX.h
@@ -2,10 +2,19 @@
 #ifndef __ARDUINO_GIGADISPLAY_GFX__
 #define __ARDUINO_GIGADISPLAY_GFX__
 
+#ifdef __ZEPHYR__
+#include "Adafruit_GFX.h"
+#include "Arduino_GigaDisplay.h"
+//#include "Adafruit_SPITFT.h"
+#endif
+
+#ifdef __MBED__
 #include "Arduino_H7_Video.h"
 #include "Adafruit_GFX.h"
 #include "Adafruit_SPITFT.h"
 #include "dsi.h"
+#endif
+
 #include "SDRAM.h"
 
 class GigaDisplay_GFX : public Adafruit_GFX {
@@ -45,12 +54,18 @@ class GigaDisplay_GFX : public Adafruit_GFX {
     uint16_t *buffer = nullptr; ///< Raster data: no longer private, allow subclass access
 
   private:
+#ifdef __MBED__
     Arduino_H7_Video* display;
+    rtos::Thread* _refresh_thd;
     void refresh_if_needed();
+#elif defined(__ZEPHYR__)
+    Display* display;
+    uint32_t sizeof_framebuffer;
+#endif
     //bool need_refresh = false;
     bool buffering = false;
     uint32_t last_refresh = 0;
-    rtos::Thread* _refresh_thd;
+
 };
 
 #endif //__ARDUINO_GIGADISPLAY_GFX__

--- a/src/Arduino_GigaDisplay_GFX.h
+++ b/src/Arduino_GigaDisplay_GFX.h
@@ -38,6 +38,11 @@ class GigaDisplay_GFX : public Adafruit_GFX {
       return buffer;
     }
 
+    #if defined(__ZEPHYR__)
+    void drawGrayscaleBitmapScaled(int16_t width_image, int16_t height_image, uint8_t scale, uint8_t *pixels);
+    void drawRGBBitmapScaled(int16_t width_image, int16_t height_image, uint8_t scale, uint16_t *pixels);
+    #endif
+
     void startWrite();
     void endWrite();
     void startBuffering();


### PR DESCRIPTION
Updated so GFX works with either Zephyr or mbed.

Requires the update to Arduino_GigaDisplay library to work with zephyr.  @KurtE and I have tested this and used it.  PS - for touch to work you will need to include the @KurtE's PR: https://github.com/arduino/ArduinoCore-zephyr/pull/134.

So please incorporate that library as well.