### PR TITLE
Add Zephyr support and improve examples

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,9 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check/.codespellrc
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = ,
+skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
+builtin = clear,informal,en-GB_to_en-US
+check-filenames =
+check-hidden =

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# See: https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#about-the-dependabotyml-file
+version: 2
+
+updates:
+  # Configure check for outdated GitHub Actions actions in workflows.
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/dependabot/README.md
+  # See: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: github-actions
+    directory: / # Check the repository's workflows under /.github/workflows/
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"

--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -1,0 +1,26 @@
+name: Arduino Lint
+on:
+  push:
+  pull_request:
+  # Scheduled trigger checks for breakage caused by new rules added to Arduino Lint
+  schedule:
+    # run every Saturday at 3 AM UTC
+    - cron: "0 3 * * 6"
+  # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+  # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch
+  repository_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Arduino Lint
+        uses: arduino/arduino-lint-action@v2
+        with:
+          official: true
+          library-manager: update

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,89 @@
+name: Compile Examples
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "library.properties"
+      - "examples/**"
+      - "src/**"
+  push:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "library.properties"
+      - "examples/**"
+      - "src/**"
+  # Scheduled trigger checks for breakage caused by changes to external resources (libraries, platforms)
+  schedule:
+    # run every Saturday at 3 AM UTC
+    - cron: "0 3 * * 6"
+  # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+  # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch
+  repository_dispatch:
+
+jobs:
+  build:
+    name: ${{ matrix.board.fqbn }}
+    runs-on: ubuntu-latest
+
+    env:
+      UNIVERSAL_SKETCH_PATHS: |
+        - examples/Basic
+        - examples/Demo
+
+      SKETCHES_REPORTS_PATH: sketches-reports
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        board:
+          - fqbn: arduino:mbed_giga:giga
+            platform-name: arduino:mbed_giga
+            artifact-name-suffix: arduino-mbed_giga-giga
+          - fqbn: arduino:zephyr_main:giga
+            platform-name: arduino:zephyr_main
+            artifact-name-suffix: arduino-zephyr_main-giga
+
+        include:
+          - board:
+              platform-name: arduino:mbed_giga
+            platforms: |
+              # Install Arduino mbed_giga Boards via Boards Manager
+              - name: arduino:mbed_giga
+          - board:
+              platform-name: arduino:zephyr_main
+            platforms: |
+              # Install Arduino Zephyr Boards via Boards Manager
+              - name: arduino:zephyr_main
+            # On the Zephyr core the video output is provided by the Arduino_Video library
+            libraries: |
+              - name: Arduino_Video
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compile examples
+        uses: arduino/compile-sketches@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          platforms: ${{ matrix.platforms }}
+          fqbn: ${{ matrix.board.fqbn }}
+          libraries: |
+            # Install the library from the local path.
+            - source-path: ./
+            - name: Adafruit GFX Library
+            ${{ matrix.libraries }}
+          sketch-paths: |
+            ${{ env.UNIVERSAL_SKETCH_PATHS }}
+          enable-deltas-report: true
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
+
+      - name: Save memory usage change report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sketches-report-${{ matrix.board.artifact-name-suffix }}
+          if-no-files-found: error
+          path: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,24 @@
+name: Report Size Deltas
+
+on:
+  push:
+    paths:
+      - ".github/workflows/report-size-deltas.ya?ml"
+  schedule:
+    - cron: '*/5 * * * *'
+  # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+  # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch
+  repository_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+
+    steps:
+      # See: https://github.com/arduino/actions/blob/master/libraries/report-size-deltas/README.md
+      - name: Comment size deltas reports to PRs
+        uses: arduino/report-size-deltas@v1
+        with:
+          # Regex matching the names of the workflow artifacts created by the "Compile Examples" workflow
+          sketches-reports-source: ^sketches-report-.+

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,24 @@
+name: Spell Check
+
+on:
+  pull_request:
+  push:
+  schedule:
+    # Run every Saturday at 3 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 3 * * 6"
+  # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+  # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch
+  repository_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # See: https://github.com/codespell-project/actions-codespell/blob/master/README.md
+      - name: Spell check
+        uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,139 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/sync-labels.md
+name: Sync Labels
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/sync-labels.ya?ml"
+      - ".github/label-configuration-files/*.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/sync-labels.ya?ml"
+      - ".github/label-configuration-files/*.ya?ml"
+  schedule:
+    # Run daily at 8 AM UTC to sync with changes to shared label configurations.
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+  repository_dispatch:
+
+env:
+  CONFIGURATIONS_FOLDER: .github/label-configuration-files
+  CONFIGURATIONS_ARTIFACT_PREFIX: label-configuration-file-
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download JSON schema for labels configuration file
+        id: download-schema
+        uses: carlosperate/download-file-action@v2
+        with:
+          file-url: https://raw.githubusercontent.com/arduino/tooling-project-assets/main/workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json
+          location: ${{ runner.temp }}/label-configuration-schema
+
+      - name: Install JSON schema validator
+        run: |
+          sudo npm install \
+            --global \
+            ajv-cli \
+            ajv-formats
+
+      - name: Validate local labels configuration
+        run: |
+          # See: https://github.com/ajv-validator/ajv-cli#readme
+          ajv validate \
+            --all-errors \
+            -c ajv-formats \
+            -s "${{ steps.download-schema.outputs.file-path }}" \
+            -d "${{ env.CONFIGURATIONS_FOLDER }}/*.{yml,yaml}"
+
+  download:
+    needs: check
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        filename:
+          # Filenames of the shared configurations to apply to the repository in addition to the local configuration.
+          # https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/sync-labels
+          - universal.yml
+
+    steps:
+      - name: Download
+        uses: carlosperate/download-file-action@v2
+        with:
+          file-url: https://raw.githubusercontent.com/arduino/tooling-project-assets/main/workflow-templates/assets/sync-labels/${{ matrix.filename }}
+
+      - name: Pass configuration files to next job via workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          path: |
+            *.yaml
+            *.yml
+          if-no-files-found: error
+          name: ${{ env.CONFIGURATIONS_ARTIFACT_PREFIX }}${{ matrix.filename }}
+
+  sync:
+    needs: download
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "MERGED_CONFIGURATION_PATH=${{ runner.temp }}/labels.yml" >> "$GITHUB_ENV"
+
+      - name: Determine whether to dry run
+        id: dry-run
+        if: >
+          github.event_name == 'pull_request' ||
+          (
+            (
+              github.event_name == 'push' ||
+              github.event_name == 'workflow_dispatch'
+            ) &&
+            github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+          )
+        run: |
+          # Use of this flag in the github-label-sync command will cause it to only check the validity of the
+          # configuration.
+          echo "flag=--dry-run" >> $GITHUB_OUTPUT
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download configuration file artifacts
+        uses: actions/download-artifact@v8
+        with:
+          merge-multiple: true
+          pattern: ${{ env.CONFIGURATIONS_ARTIFACT_PREFIX }}*
+          path: ${{ env.CONFIGURATIONS_FOLDER }}
+
+      - name: Remove unneeded artifacts
+        uses: geekyeggo/delete-artifact@v6
+        with:
+          name: ${{ env.CONFIGURATIONS_ARTIFACT_PREFIX }}*
+
+      - name: Merge label configuration files
+        run: |
+          # Merge all configuration files
+          shopt -s extglob
+          cat "${{ env.CONFIGURATIONS_FOLDER }}"/*.@(yml|yaml) > "${{ env.MERGED_CONFIGURATION_PATH }}"
+
+      - name: Install github-label-sync
+        run: sudo npm install --global github-label-sync
+
+      - name: Sync labels
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # See: https://github.com/Financial-Times/github-label-sync
+          github-label-sync \
+            --labels "${{ env.MERGED_CONFIGURATION_PATH }}" \
+            ${{ steps.dry-run.outputs.flag }} \
+            ${{ github.repository }}

--- a/examples/Basic/Basic.ino
+++ b/examples/Basic/Basic.ino
@@ -1,15 +1,39 @@
+/*
+  GigaDisplay GFX - Basic
+  This sketch initializes the Arduino Giga Display in Landscape mode (rotated 90°)
+  and draws a solid red rectangle perfectly centered on the screen.
+  Default orientation is Portrait (480x800).
+*/
+
 #include "Arduino_GigaDisplay_GFX.h"
 
 GigaDisplay_GFX display;
 
 void setup() {
   Serial.begin(115200);
+  display.begin();
+
+  // Set rotation to 90 degrees (Landscape) 
+  // Default is 0 (Portrait, where width is the short side: 480)
+  display.setRotation(1);
+
+  // Clear screen to black
+  display.fillScreen(0x0000);
+
+  // Define rectangle dimensions
+  int rectW = 200;
+  int rectH = 100;
+
+  // Calculate centered coordinates (now based on 800x480)
+  int x = (display.width() - rectW) / 2;
+  int y = (display.height() - rectH) / 2;
+
+  // Generate 16-bit RGB565 red color
+  uint16_t red = display.color565(255, 0, 0);
+
+  // Draw filled red rectangle at center
+  display.fillRect(x, y, rectW, rectH, red);
 }
 
 void loop() {
-  Serial.println(millis());
-  display.fillScreen(0);
-  display.fillRect(120, 180, 120, 180, 0x8888);
-  display.print(false);
-  delay(100);
 }

--- a/examples/Demo/Demo.ino
+++ b/examples/Demo/Demo.ino
@@ -1,3 +1,10 @@
+/*
+  GigaDisplay GFX - Demo
+  This sketch performs a comprehensive speed test of the GFX library, 
+  measuring performance for text, lines, shapes, and rotations.
+  Optimized for Landscape mode (800x480) on the Arduino Giga Display.
+*/
+
 #include "Arduino_GigaDisplay_GFX.h"
 
 GigaDisplay_GFX tft;
@@ -16,6 +23,9 @@ void setup() {
   Serial.println("GC9A01A Test!");
 
   tft.begin();
+  // Rotate 90° clockwise to Landscape (800x480)
+  // By default, width is the short side (480)
+  tft.setRotation(1);
 
   Serial.println(F("Benchmark                Time (microseconds)"));
   delay(10);

--- a/library.properties
+++ b/library.properties
@@ -6,6 +6,6 @@ sentence=GFX library for GIGA Display Shield
 paragraph=
 category=Display
 url=https://docs.arduino.cc/tutorials/giga-display-shield/gfx-guide
-architectures=mbed_giga
+architectures=mbed_giga,zephyr_main
 includes=Arduino_GigaDisplay_GFX.h
 depends=Adafruit GFX Library

--- a/src/Arduino_GigaDisplay_GFX.cpp
+++ b/src/Arduino_GigaDisplay_GFX.cpp
@@ -1,47 +1,61 @@
 
 #include "Arduino_GigaDisplay_GFX.h"
+
+#ifdef __MBED__
 #include "platform/mbed_critical.h"
+#endif
 
-GigaDisplay_GFX::GigaDisplay_GFX() : Adafruit_GFX(480, 800) {
-
-}
+GigaDisplay_GFX::GigaDisplay_GFX() : Adafruit_GFX(480, 800) { }
 
 GigaDisplay_GFX::~GigaDisplay_GFX(void) {
   if (buffer)
     free(buffer);
 }
 
-//rtos::Semaphore refresh_sem(1);
-
+#ifdef __MBED__
 void GigaDisplay_GFX::refresh_if_needed() {
   while (1) {
     rtos::ThisThread::flags_wait_any(0x1);
-    //refresh_sem.acquire();
     dsi_lcdDrawImage((void *) this->getBuffer(), (void *)(dsi_getActiveFrameBuffer()), 480, 800, DMA2D_INPUT_RGB565);
-    //dsi_lcdDrawImage((void *) this->getBuffer(), (void *)(dsi_getActiveFrameBuffer()), this->width(), this->height(), DMA2D_INPUT_RGB565);
-    //refresh_sem.release();
     delay(10);
   }
 }
-
+#endif
 
 void GigaDisplay_GFX::begin() {
-    display = new Arduino_H7_Video(480, 800, GigaDisplayShield);
+    display = new Arduino_Video(480, 800, GigaDisplayShield);
     display->begin();
-    buffer = (uint16_t*)ea_malloc(this->width() * this-> height() * 2);
-    _refresh_thd = new rtos::Thread(osPriorityHigh);
-    _refresh_thd->start(mbed::callback(this, &GigaDisplay_GFX::refresh_if_needed));
-    //buffer = (uint16_t*)dsi_getActiveFrameBuffer();
+
+    #ifdef __MBED__
+      buffer = (uint16_t*)ea_malloc(this->width() * this-> height() * 2);
+      _refresh_thd = new rtos::Thread(osPriorityHigh);
+      _refresh_thd->start(mbed::callback(this, &GigaDisplay_GFX::refresh_if_needed));
+    #elif defined(__ZEPHYR__)
+      #ifdef CONFIG_SHARED_MULTI_HEAP
+        void* ptrFB = this->display->getFramebuffer();
+        if (ptrFB == nullptr){
+          while(1){}
+        }
+        // Cast the void pointer to an int pointer to use it
+        buffer = static_cast<uint16_t*>(ptrFB);
+      #else
+        SDRAM.begin();
+        buffer = (uint16_t*)SDRAM.malloc(this->width() * this-> height() * sizeof(uint16_t));
+      #endif   
+      this->display->setFrameDesc(this->width(), this->height(), this->width(), (this->width() * this-> height() * sizeof(uint16_t)));
+    #endif
 }
 
-void GigaDisplay_GFX::startWrite() {
-  //refresh_sem.acquire();
-}
+void GigaDisplay_GFX::startWrite() { }
 
 void GigaDisplay_GFX::endWrite() {
-  //refresh_sem.release();
+#ifdef __MBED__
   if (!buffering)
     _refresh_thd->flags_set(0x1);
+#elif defined(__ZEPHYR__)
+  if (!buffering)
+     this->display->drawBuffer(0, 0, buffer);
+#endif
 }
 
 // If buffering, defer endWrite calls until endBuffering is called.
@@ -50,8 +64,7 @@ void GigaDisplay_GFX::startBuffering() {
 }
 
 void GigaDisplay_GFX::endBuffering() {
-  if (buffering)
-  {
+  if (buffering) {
     buffering = false;
     endWrite();
   }

--- a/src/Arduino_GigaDisplay_GFX.h
+++ b/src/Arduino_GigaDisplay_GFX.h
@@ -2,11 +2,19 @@
 #ifndef __ARDUINO_GIGADISPLAY_GFX__
 #define __ARDUINO_GIGADISPLAY_GFX__
 
+#if defined(ARDUINO_ARCH_ZEPHYR)
+#include "Arduino_Video.h"
+#else
 #include "Arduino_H7_Video.h"
+using Arduino_Video = Arduino_H7_Video;
+#endif
 #include "Adafruit_GFX.h"
+
+#if __MBED__
 #include "Adafruit_SPITFT.h"
 #include "dsi.h"
 #include "SDRAM.h"
+#endif
 
 class GigaDisplay_GFX : public Adafruit_GFX {
   public:
@@ -45,12 +53,13 @@ class GigaDisplay_GFX : public Adafruit_GFX {
     uint16_t *buffer = nullptr; ///< Raster data: no longer private, allow subclass access
 
   private:
-    Arduino_H7_Video* display;
+    Arduino_Video* display;
+#ifdef __MBED__
+    rtos::Thread* _refresh_thd;
     void refresh_if_needed();
-    //bool need_refresh = false;
+#endif
     bool buffering = false;
     uint32_t last_refresh = 0;
-    rtos::Thread* _refresh_thd;
 };
 
 #endif //__ARDUINO_GIGADISPLAY_GFX__


### PR DESCRIPTION
This PR adds Zephyr support to the library, substituting PR #10.
 Improved and optimized examples for better compatibility and performance.

Requirements:
- Dependency: Requires [Arduino_Video](https://github.com/arduino-libraries/Arduino_Video) (WIP).
- Core: Depends on memory/LLEXT changes in [ArduinoCore-zephyr #414](https://github.com/arduino/ArduinoCore-zephyr/pull/414).